### PR TITLE
TME-8406: Use nginx:stable-alpine-slim for security and smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:1.27.2
+FROM nginx:stable-alpine-slim
+
+RUN apk add --no-cache bash gettext
 
 COPY default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Using `alpine` which is the smallest size and just need to add `bash` and `gettext`
* Built the image and ran it locally