### PR TITLE
TME-9277: Use cf_connecting_ip for x-real-ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Nginx Proxy for Mixpanel
-This is an nginx config that serves as a proxy to Mixpanel's Ingestion API and JavaScript library endpoints. [Docs on Tracking via Proxy](https://docs.mixpanel.com/docs/tracking/how-tos/tracking-via-proxy). The purpose of the proxy is to get around adblockers blocking event tracking. Truemed sends events to a Truemed-owned domain, and the proxy routes them to Mixpanel.
+This is an Nginx config that serves as a proxy to Mixpanel's Ingestion API and JavaScript library endpoints.
+[Docs on Tracking via Proxy](https://docs.mixpanel.com/docs/tracking/how-tos/tracking-via-proxy).
+The purpose of the proxy is to get around adblockers blocking event tracking. Truemed sends events to a Truemed-owned domain, and the proxy routes them to Mixpanel.
 
 # Deploying
 This repo automatically deploys to the `tm-mixpanel-proxy` app in [Heroku](https://dashboard.heroku.com/teams/truemed-678/apps).
+Ingestion URL is `mp.truemed.com` (for production) and `dev-mp.truemed.com` (for development). This is proxied through Cloudflare.

--- a/default.conf.template
+++ b/default.conf.template
@@ -3,14 +3,14 @@ server {
     listen [::]:$PORT default backlog=16384;
 
     location /lib.min.js {
-        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_pass https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js;
     }
 
     location /lib.js {
-        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_pass https://cdn.mxpnl.com/libs/mixpanel-2-latest.js;
@@ -18,7 +18,7 @@ server {
 
     location /decide {
         proxy_set_header Host decide.mixpanel.com;
-        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_pass https://decide.mixpanel.com/decide;
@@ -26,7 +26,7 @@ server {
 
     location / {
         proxy_set_header Host api.mixpanel.com;
-        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_pass https://api.mixpanel.com/;


### PR DESCRIPTION
We should be using the Cloudflare header `https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/` since we proxy from `mp.truemed.com` to Heroku deployed URL via Cloudflare

https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/