### PR TITLE
Add Datadog RUM/Logs proxy for CIPA compliance

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -24,6 +24,16 @@ server {
         proxy_pass https://decide.mixpanel.com/decide;
     }
 
+    # RUM/observability proxy (CIPA compliance — opaque paths hide vendor identity)
+    # Datadog RUM + Logs: /v1/api/v2/rum etc.
+    location /v1/ {
+        proxy_set_header Host browser-intake-us1-datadoghq.com;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_ssl_server_name on;
+        proxy_pass https://browser-intake-us1-datadoghq.com/;
+    }
+
     location / {
         proxy_set_header Host api.mixpanel.com;
         proxy_set_header X-Real-IP $http_cf_connecting_ip;


### PR DESCRIPTION
## Summary
- Add `/v1/` nginx location block to proxy Datadog browser SDK traffic through `mp.truemed.com` instead of directly to `browser-intake-us1-datadoghq.com`
- Remove uncommitted Sentry locations (`/t/m`, `/t/a`) — doing one pixel at a time

## Deploy order
**Deploy this first**, before the app changes in marketing-mono and mono/next.

## Verification
```bash
curl -I https://mp.truemed.com/v1/api/v2/rum
```
Should return a valid response (200 or Datadog error, not nginx 404).

## Test plan
- [ ] Deploy to Heroku
- [ ] Verify curl returns valid response
- [ ] Deploy app PRs (marketing-mono, mono) after this is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)