### PR TITLE
CSE-974: Add statsig entry for proxy

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -30,6 +30,12 @@ server {
         proxy_pass https://events.statsigapi.net/;
     }
 
+    location /ssig-init/ {
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass https://api.statsig.com/;
+    }
+
     location / {
         proxy_set_header Host api.mixpanel.com;
         proxy_set_header X-Real-IP $http_cf_connecting_ip;

--- a/default.conf.template
+++ b/default.conf.template
@@ -24,6 +24,12 @@ server {
         proxy_pass https://decide.mixpanel.com/decide;
     }
 
+    location /ssig/ {
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass https://events.statsigapi.net/;
+    }
+
     location / {
         proxy_set_header Host api.mixpanel.com;
         proxy_set_header X-Real-IP $http_cf_connecting_ip;


### PR DESCRIPTION
As discussed, we're going to use this to proxy our to-statsig client requests from mono/next

https://linear.app/truemed/issue/CSE-1051/update-mixpanel-proxy-to-be-analytics-proxy for renaming / updating this repo
